### PR TITLE
Updated README to use composer require instead of manual edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,10 @@ Inspired or ported from [node-librato-metrics](https://github.com/holidayextras/
 
 ## Install
 
-Installation should be done via [composer](http://packagist.org/).
+Installation should be done via [Composer](http://packagist.org/).
 
-```
-{
-    "require": {
-        "nesQuick/Metrics": "dev-master"
-    }
-}
+```bash
+$ composer require nesQuick/Metrics
 ```
 
 ## Example


### PR DESCRIPTION
Manual editing of `composer.json` is no longer needed thanks to `composer require` choosing sensible defaults.

As brought up in Issue #3, this is dependent on tagging releases in this package.

This would also take out the need of `dev-master` allowing for more reliable dependencies since changes committed to master won't automatically trigger a new release.
